### PR TITLE
fix: almalinux 9 gpg keys missing

### DIFF
--- a/roles/gpg_keys/defaults/main.yml
+++ b/roles/gpg_keys/defaults/main.yml
@@ -51,3 +51,7 @@ gpg_keys_required:
     url: https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-TOOLS,
     dest: "{{ gpg_keys_dir }}"
   }
+  - {
+    url: https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux-9,
+    dest: "{{ gpgkeys_dir }}"
+  }


### PR DESCRIPTION
Fixes #4